### PR TITLE
Unique Variant fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+* Variants are now only required to be unique per flag, not globally
+
 ## [v0.5.0](https://github.com/markphelps/flipt/releases/tag/v0.5.0) - 2019-05-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Variants are now only required to be unique per flag, not globally
+* Variant keys are now only required to be unique per flag, not globally
 
 ## [v0.5.0](https://github.com/markphelps/flipt/releases/tag/v0.5.0) - 2019-05-27
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ setup: ## Install dev tools
 
 .PHONY: test
 test: ## Run all the tests
-	go test $(TEST_OPTS) -v -covermode=atomic -coverprofile=coverage.txt $(SOURCE_FILES) -run $(TEST_PATTERN) -timeout=30s $(TEST_FLAGS)
+	go test $(TEST_OPTS) -v -covermode=atomic -count=1 -coverprofile=coverage.txt $(SOURCE_FILES) -run $(TEST_PATTERN) -timeout=30s $(TEST_FLAGS)
 
 .PHONY: cover
 cover: test ## Run all the tests and opens the coverage report

--- a/config/migrations/postgres/1_variants_unique_per_flag.down.sql
+++ b/config/migrations/postgres/1_variants_unique_per_flag.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE variants DROP CONSTRAINT variants_flag_key_key_key;
+ALTER TABLE variants ADD UNIQUE(key);

--- a/config/migrations/postgres/1_variants_unique_per_flag.up.sql
+++ b/config/migrations/postgres/1_variants_unique_per_flag.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE variants DROP CONSTRAINT variants_key_key;
+ALTER TABLE variants ADD UNIQUE(flag_key, key);

--- a/config/migrations/sqlite3/1_variants_unique_per_flag.down.sql
+++ b/config/migrations/sqlite3/1_variants_unique_per_flag.down.sql
@@ -1,6 +1,5 @@
 /* SQLite doesn't allow you to drop unique constraints with ALTER TABLE
    so we have to create a new table with the schema we want and copy the data over.
-
    https://www.sqlite.org/lang_altertable.html
 */
 

--- a/config/migrations/sqlite3/1_variants_unique_per_flag.down.sql
+++ b/config/migrations/sqlite3/1_variants_unique_per_flag.down.sql
@@ -1,0 +1,23 @@
+PRAGMA foreign_keys=off;
+
+CREATE TABLE variants_temp
+(
+  id VARCHAR(255) PRIMARY KEY UNIQUE NOT NULL,
+  flag_key VARCHAR(255) NOT NULL REFERENCES flags ON DELETE CASCADE,
+  key VARCHAR(255) NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  description TEXT NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  UNIQUE key ON CONFLICT REPLACE
+);
+
+INSERT INTO variants_temp (id, flag_key, key, name, description, created_at, updated_at)
+  SELECT id, flag_key, key, name, description, created_at, updated_at
+  FROM variants;
+
+DROP TABLE variants;
+
+ALTER TABLE variants_temp RENAME TO variants;
+
+PRAGMA foreign_keys=on;

--- a/config/migrations/sqlite3/1_variants_unique_per_flag.down.sql
+++ b/config/migrations/sqlite3/1_variants_unique_per_flag.down.sql
@@ -1,3 +1,9 @@
+/* SQLite doesn't allow you to drop unique constraints with ALTER TABLE
+   so we have to create a new table with the schema we want and copy the data over.
+
+   https://www.sqlite.org/lang_altertable.html
+*/
+
 PRAGMA foreign_keys=off;
 
 CREATE TABLE variants_temp

--- a/config/migrations/sqlite3/1_variants_unique_per_flag.up.sql
+++ b/config/migrations/sqlite3/1_variants_unique_per_flag.up.sql
@@ -1,3 +1,8 @@
+/* SQLite doesn't allow you to drop unique constraints with ALTER TABLE
+   so we have to create a new table with the schema we want and copy the data over.
+   https://www.sqlite.org/lang_altertable.html
+*/
+
 PRAGMA foreign_keys=off;
 
 CREATE TABLE variants_temp

--- a/config/migrations/sqlite3/1_variants_unique_per_flag.up.sql
+++ b/config/migrations/sqlite3/1_variants_unique_per_flag.up.sql
@@ -1,0 +1,23 @@
+PRAGMA foreign_keys=off;
+
+CREATE TABLE variants_temp
+(
+  id VARCHAR(255) PRIMARY KEY UNIQUE NOT NULL,
+  flag_key VARCHAR(255) NOT NULL REFERENCES flags ON DELETE CASCADE,
+  key VARCHAR(255) NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  description TEXT NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  UNIQUE (flag_key, key)
+);
+
+INSERT INTO variants_temp (id, flag_key, key, name, description, created_at, updated_at)
+  SELECT id, flag_key, key, name, description, created_at, updated_at
+  FROM variants;
+
+DROP TABLE variants;
+
+ALTER TABLE variants_temp RENAME TO variants;
+
+PRAGMA foreign_keys=on;

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -18,6 +18,9 @@ Variants are options for flags. For example, if you have a flag `colorscheme` th
 
 ![Variants Example](assets/images/concepts/01_variants.png?raw=true "Variant Example")
 
+!!! note
+    Variant keys must be unique for a given flag.
+
 ## Segments
 
 Segments allow you to split your userbase or audience up into predefined slices. This is a powerful feature that enables targeting groups to determine if a flag or variant applies to them.
@@ -27,7 +30,7 @@ An example segment could be `new-users`.
 ![New Users Segment](assets/images/concepts/02_segments.png)
 
 !!! tip
-    Segments are global across the Flipt application, so they can be used with multiple flags.
+    Segments are global across the Flipt application so they can be used with multiple flags.
 
 ## Constraints
 

--- a/storage/db.go
+++ b/storage/db.go
@@ -39,8 +39,8 @@ func (t *timestamp) Value() (driver.Value, error) {
 }
 
 const (
-	pgForeignKeyConstraint = "foreign_key_violation"
-	pgUniqueConstraint     = "unique_violation"
+	pgConstraintForeignKey = "foreign_key_violation"
+	pgConstraintUnique     = "unique_violation"
 )
 
 // DB is an abstraction for a database

--- a/storage/flag.go
+++ b/storage/flag.go
@@ -169,8 +169,6 @@ func (s *FlagStorage) CreateFlag(ctx context.Context, r *flipt.CreateFlagRequest
 			if ierr.Code.Name() == pgConstraintUnique {
 				return nil, ErrInvalidf("flag %q is not unique", r.Key)
 			}
-		default:
-			s.logger.Infof("%+v", ierr)
 		}
 
 		return nil, err
@@ -251,7 +249,6 @@ func (s *FlagStorage) CreateVariant(ctx context.Context, r *flipt.CreateVariantR
 				} else if ierr.ExtendedCode == sqlite3.ErrConstraintUnique {
 					return nil, ErrInvalidf("variant %q is not unique", r.Key)
 				}
-				return nil, err
 			}
 		case *pq.Error:
 			if ierr.Code.Name() == pgConstraintForeignKey {
@@ -259,7 +256,6 @@ func (s *FlagStorage) CreateVariant(ctx context.Context, r *flipt.CreateVariantR
 			} else if ierr.Code.Name() == pgConstraintUnique {
 				return nil, ErrInvalidf("variant %q is not unique", r.Key)
 			}
-			return nil, err
 		}
 
 		return nil, err

--- a/storage/flag_test.go
+++ b/storage/flag_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	flipt "github.com/markphelps/flipt/rpc"
@@ -243,6 +244,56 @@ func TestCreateVariant_FlagNotFound(t *testing.T) {
 	})
 
 	assert.EqualError(t, err, "flag \"foo\" not found")
+}
+
+func TestCreateVariant_DuplicateName_DifferentFlag(t *testing.T) {
+	flag1, err := flagStore.CreateFlag(context.TODO(), &flipt.CreateFlagRequest{
+		Key:         fmt.Sprintf("%s_1", t.Name()),
+		Name:        "foo_1",
+		Description: "bar",
+		Enabled:     true,
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, flag1)
+
+	variant1, err := flagStore.CreateVariant(context.TODO(), &flipt.CreateVariantRequest{
+		FlagKey:     flag1.Key,
+		Key:         t.Name(),
+		Name:        "foo",
+		Description: "bar",
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, variant1)
+
+	assert.NotZero(t, variant1.Id)
+	assert.Equal(t, flag1.Key, variant1.FlagKey)
+	assert.Equal(t, t.Name(), variant1.Key)
+
+	flag2, err := flagStore.CreateFlag(context.TODO(), &flipt.CreateFlagRequest{
+		Key:         fmt.Sprintf("%s_2", t.Name()),
+		Name:        "foo_2",
+		Description: "bar",
+		Enabled:     true,
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, flag2)
+
+	variant2, err := flagStore.CreateVariant(context.TODO(), &flipt.CreateVariantRequest{
+		FlagKey:     flag2.Key,
+		Key:         t.Name(),
+		Name:        "foo",
+		Description: "bar",
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, variant2)
+
+	assert.NotZero(t, variant2.Id)
+	assert.Equal(t, flag2.Key, variant2.FlagKey)
+	assert.Equal(t, t.Name(), variant2.Key)
 }
 
 func TestUpdateVariant(t *testing.T) {

--- a/storage/flag_test.go
+++ b/storage/flag_test.go
@@ -246,6 +246,38 @@ func TestCreateVariant_FlagNotFound(t *testing.T) {
 	assert.EqualError(t, err, "flag \"foo\" not found")
 }
 
+func TestCreateVariant_DuplicateName(t *testing.T) {
+	flag, err := flagStore.CreateFlag(context.TODO(), &flipt.CreateFlagRequest{
+		Key:         t.Name(),
+		Name:        "foo",
+		Description: "bar",
+		Enabled:     true,
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, flag)
+
+	variant, err := flagStore.CreateVariant(context.TODO(), &flipt.CreateVariantRequest{
+		FlagKey:     flag.Key,
+		Key:         "foo",
+		Name:        "foo",
+		Description: "bar",
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, variant)
+
+	// try to create another variant with the same name for this flag
+	_, err = flagStore.CreateVariant(context.TODO(), &flipt.CreateVariantRequest{
+		FlagKey:     flag.Key,
+		Key:         "foo",
+		Name:        "foo",
+		Description: "bar",
+	})
+
+	assert.EqualError(t, err, "variant \"foo\" is not unique")
+}
+
 func TestCreateVariant_DuplicateName_DifferentFlag(t *testing.T) {
 	flag1, err := flagStore.CreateFlag(context.TODO(), &flipt.CreateFlagRequest{
 		Key:         fmt.Sprintf("%s_1", t.Name()),
@@ -259,7 +291,7 @@ func TestCreateVariant_DuplicateName_DifferentFlag(t *testing.T) {
 
 	variant1, err := flagStore.CreateVariant(context.TODO(), &flipt.CreateVariantRequest{
 		FlagKey:     flag1.Key,
-		Key:         t.Name(),
+		Key:         "foo",
 		Name:        "foo",
 		Description: "bar",
 	})
@@ -269,7 +301,7 @@ func TestCreateVariant_DuplicateName_DifferentFlag(t *testing.T) {
 
 	assert.NotZero(t, variant1.Id)
 	assert.Equal(t, flag1.Key, variant1.FlagKey)
-	assert.Equal(t, t.Name(), variant1.Key)
+	assert.Equal(t, "foo", variant1.Key)
 
 	flag2, err := flagStore.CreateFlag(context.TODO(), &flipt.CreateFlagRequest{
 		Key:         fmt.Sprintf("%s_2", t.Name()),
@@ -283,7 +315,7 @@ func TestCreateVariant_DuplicateName_DifferentFlag(t *testing.T) {
 
 	variant2, err := flagStore.CreateVariant(context.TODO(), &flipt.CreateVariantRequest{
 		FlagKey:     flag2.Key,
-		Key:         t.Name(),
+		Key:         "foo",
 		Name:        "foo",
 		Description: "bar",
 	})
@@ -293,7 +325,7 @@ func TestCreateVariant_DuplicateName_DifferentFlag(t *testing.T) {
 
 	assert.NotZero(t, variant2.Id)
 	assert.Equal(t, flag2.Key, variant2.FlagKey)
-	assert.Equal(t, t.Name(), variant2.Key)
+	assert.Equal(t, "foo", variant2.Key)
 }
 
 func TestUpdateVariant(t *testing.T) {
@@ -309,7 +341,7 @@ func TestUpdateVariant(t *testing.T) {
 
 	variant, err := flagStore.CreateVariant(context.TODO(), &flipt.CreateVariantRequest{
 		FlagKey:     flag.Key,
-		Key:         t.Name(),
+		Key:         "foo",
 		Name:        "foo",
 		Description: "bar",
 	})
@@ -319,7 +351,7 @@ func TestUpdateVariant(t *testing.T) {
 
 	assert.NotZero(t, variant.Id)
 	assert.Equal(t, flag.Key, variant.FlagKey)
-	assert.Equal(t, t.Name(), variant.Key)
+	assert.Equal(t, "foo", variant.Key)
 	assert.Equal(t, "foo", variant.Name)
 	assert.Equal(t, "bar", variant.Description)
 	assert.NotZero(t, variant.CreatedAt)
@@ -374,6 +406,48 @@ func TestUpdateVariant_NotFound(t *testing.T) {
 	assert.EqualError(t, err, "variant \"foo\" not found")
 }
 
+func TestUpdateVariant_DuplicateName(t *testing.T) {
+	flag, err := flagStore.CreateFlag(context.TODO(), &flipt.CreateFlagRequest{
+		Key:         t.Name(),
+		Name:        "foo",
+		Description: "bar",
+		Enabled:     true,
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, flag)
+
+	variant1, err := flagStore.CreateVariant(context.TODO(), &flipt.CreateVariantRequest{
+		FlagKey:     flag.Key,
+		Key:         "foo",
+		Name:        "foo",
+		Description: "bar",
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, variant1)
+
+	variant2, err := flagStore.CreateVariant(context.TODO(), &flipt.CreateVariantRequest{
+		FlagKey:     flag.Key,
+		Key:         "bar",
+		Name:        "bar",
+		Description: "baz",
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, variant2)
+
+	_, err = flagStore.UpdateVariant(context.TODO(), &flipt.UpdateVariantRequest{
+		Id:          variant2.Id,
+		FlagKey:     variant2.FlagKey,
+		Key:         variant1.Key,
+		Name:        variant2.Name,
+		Description: "foobar",
+	})
+
+	assert.EqualError(t, err, "variant \"foo\" is not unique")
+}
+
 func TestDeleteVariant(t *testing.T) {
 	flag, err := flagStore.CreateFlag(context.TODO(), &flipt.CreateFlagRequest{
 		Key:         t.Name(),
@@ -387,7 +461,7 @@ func TestDeleteVariant(t *testing.T) {
 
 	variant, err := flagStore.CreateVariant(context.TODO(), &flipt.CreateVariantRequest{
 		FlagKey:     flag.Key,
-		Key:         t.Name(),
+		Key:         "foo",
 		Name:        "foo",
 		Description: "bar",
 	})
@@ -422,7 +496,7 @@ func TestDeleteVariant_ExistingRule(t *testing.T) {
 
 	variant, err := flagStore.CreateVariant(context.TODO(), &flipt.CreateVariantRequest{
 		FlagKey:     flag.Key,
-		Key:         t.Name(),
+		Key:         "foo",
 		Name:        "foo",
 		Description: "bar",
 	})

--- a/storage/rule.go
+++ b/storage/rule.go
@@ -167,7 +167,7 @@ func (s *RuleStorage) CreateRule(ctx context.Context, r *flipt.CreateRuleRequest
 				return nil, ErrNotFoundf("flag %q or segment %q", r.FlagKey, r.SegmentKey)
 			}
 		case *pq.Error:
-			if ierr.Code.Name() == pgForeignKeyConstraint {
+			if ierr.Code.Name() == pgConstraintForeignKey {
 				return nil, ErrNotFoundf("flag %q or segment %q", r.FlagKey, r.SegmentKey)
 			}
 		}
@@ -327,7 +327,7 @@ func (s *RuleStorage) CreateDistribution(ctx context.Context, r *flipt.CreateDis
 				return nil, ErrNotFoundf("rule %q", r.RuleId)
 			}
 		case *pq.Error:
-			if ierr.Code.Name() == pgForeignKeyConstraint {
+			if ierr.Code.Name() == pgConstraintForeignKey {
 				return nil, ErrNotFoundf("rule %q", r.RuleId)
 			}
 		}

--- a/storage/segment.go
+++ b/storage/segment.go
@@ -163,7 +163,7 @@ func (s *SegmentStorage) CreateSegment(ctx context.Context, r *flipt.CreateSegme
 				return nil, ErrInvalidf("segment %q is not unique", r.Key)
 			}
 		case *pq.Error:
-			if ierr.Code.Name() == pgUniqueConstraint {
+			if ierr.Code.Name() == pgConstraintUnique {
 				return nil, ErrInvalidf("segment %q is not unique", r.Key)
 			}
 		}
@@ -268,7 +268,7 @@ func (s *SegmentStorage) CreateConstraint(ctx context.Context, r *flipt.CreateCo
 				return nil, ErrNotFoundf("segment %q", r.SegmentKey)
 			}
 		case *pq.Error:
-			if ierr.Code.Name() == pgForeignKeyConstraint {
+			if ierr.Code.Name() == pgConstraintForeignKey {
 				return nil, ErrNotFoundf("segment %q", r.SegmentKey)
 			}
 		}


### PR DESCRIPTION
## Summary

Fixes #87 to require variant keys to be unique only for an individual flag, not globally.

## TODO

* [x] Update documentation, spelling out what needs to be unique when
* [x] Update Changelog
* [ ] Potentially deprecate auto migrations and require explicit migration subcommand run if there is existing db data. This is to encourage/warn that a db backup should be created before migrations are run since they can be destructive. (Will do this in another PR before release).