### PR TITLE
Add prefix and suffix segment rule operators

### DIFF
--- a/storage/rule.go
+++ b/storage/rule.go
@@ -734,6 +734,7 @@ const (
 	opPresent    = "present"
 	opNotPresent = "notpresent"
 	opPrefix     = "prefix"
+	opSuffix     = "suffix"
 )
 
 var (
@@ -751,6 +752,7 @@ var (
 		opPresent:    {},
 		opNotPresent: {},
 		opPrefix:     {},
+		opSuffix:     {},
 	}
 	noValueOperators = map[string]struct{}{
 		opEmpty:      {},
@@ -764,6 +766,7 @@ var (
 		opEmpty:    {},
 		opNotEmpty: {},
 		opPrefix:   {},
+		opSuffix:   {},
 	}
 	numberOperators = map[string]struct{}{
 		opEQ:         {},
@@ -820,6 +823,8 @@ func matchesString(c constraint, v string) (bool, error) {
 		return len(strings.TrimSpace(v)) != 0, nil
 	case opPrefix:
 		return strings.HasPrefix(strings.TrimSpace(v), value), nil
+	case opSuffix:
+		return strings.HasSuffix(strings.TrimSpace(v), value), nil
 	}
 	return false, nil
 }

--- a/storage/rule.go
+++ b/storage/rule.go
@@ -733,6 +733,7 @@ const (
 	opFalse      = "false"
 	opPresent    = "present"
 	opNotPresent = "notpresent"
+	opPrefix     = "prefix"
 )
 
 var (
@@ -749,6 +750,7 @@ var (
 		opFalse:      {},
 		opPresent:    {},
 		opNotPresent: {},
+		opPrefix:     {},
 	}
 	noValueOperators = map[string]struct{}{
 		opEmpty:      {},
@@ -761,6 +763,7 @@ var (
 		opNEQ:      {},
 		opEmpty:    {},
 		opNotEmpty: {},
+		opPrefix:   {},
 	}
 	numberOperators = map[string]struct{}{
 		opEQ:         {},
@@ -815,6 +818,8 @@ func matchesString(c constraint, v string) (bool, error) {
 		return len(strings.TrimSpace(v)) == 0, nil
 	case opNotEmpty:
 		return len(strings.TrimSpace(v)) != 0, nil
+	case opPrefix:
+		return strings.HasPrefix(strings.TrimSpace(v), value), nil
 	}
 	return false, nil
 }

--- a/storage/rule_test.go
+++ b/storage/rule_test.go
@@ -1180,6 +1180,25 @@ func Test_matchesString(t *testing.T) {
 			},
 			value: "bar",
 		},
+		{
+			name: "prefix",
+			constraint: constraint{
+				Property: "foo",
+				Operator: "prefix",
+				Value:    "ba",
+			},
+			value:     "bar",
+			wantMatch: true,
+		},
+		{
+			name: "negative prefix",
+			constraint: constraint{
+				Property: "foo",
+				Operator: "prefix",
+				Value:    "bar",
+			},
+			value: "nope",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/storage/rule_test.go
+++ b/storage/rule_test.go
@@ -1199,6 +1199,25 @@ func Test_matchesString(t *testing.T) {
 			},
 			value: "nope",
 		},
+		{
+			name: "suffix",
+			constraint: constraint{
+				Property: "foo",
+				Operator: "suffix",
+				Value:    "ar",
+			},
+			value:     "bar",
+			wantMatch: true,
+		},
+		{
+			name: "negative suffix",
+			constraint: constraint{
+				Property: "foo",
+				Operator: "suffix",
+				Value:    "bar",
+			},
+			value: "nope",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/ui/src/components/Segments/Segment.vue
+++ b/ui/src/components/Segments/Segment.vue
@@ -322,7 +322,8 @@ const STRING_OPERATORS = {
   neq: "!=",
   empty: "IS EMPTY",
   notempty: "IS NOT EMPTY",
-  prefix: "HAS PREFIX"
+  prefix: "HAS PREFIX",
+  suffix: "HAS SUFFIX"
 };
 
 const NUMBER_OPERATORS = {

--- a/ui/src/components/Segments/Segment.vue
+++ b/ui/src/components/Segments/Segment.vue
@@ -321,7 +321,8 @@ const STRING_OPERATORS = {
   eq: "==",
   neq: "!=",
   empty: "IS EMPTY",
-  notempty: "IS NOT EMPTY"
+  notempty: "IS NOT EMPTY",
+  prefix: "HAS PREFIX"
 };
 
 const NUMBER_OPERATORS = {


### PR DESCRIPTION
Sometimes I want to segment some features for our company users only, e.g. username ending in company e-mail domain, and while trying to configure this I found out that Segment rules were lacking a `suffix` operator. I could achieve similar behavior by adding several `==` constraints for each username, but keeping that list up-to-date would be painful (and I believe a huge list of constraints can also lead to poor evaluation performance?).

To solve this, this PR introduces two new string matching operators: `prefix` and `suffix`. Now, matching the mentioned segment of users is one single constraint rule. Prefix was added because it was simple to add suffix and I see some usages such as allowing some flags by phone number country code, e.g. phone number starts with `+55` etc.

If you prefer I can split these operators in separate PRs, but the code is quite similar.