### PR TITLE
Set multi-stage Dockerfile for easier builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,41 @@
-FROM alpine:latest
+FROM golang:1.12.4-alpine AS build
+
+RUN apk add --no-cache \
+    gcc \
+    git \
+    musl-dev \
+    nodejs \
+    openssl \
+    postgresql-client \
+    yarn
+
+ENV GO111MODULE=on
+WORKDIR /flipt
+
+COPY go.mod go.mod
+COPY go.sum go.sum
+RUN go mod download
+
+COPY . .
+RUN cd ./ui && yarn install && yarn run build
+RUN go generate -v ./...
+RUN go install -v ./cmd/flipt/
+
+FROM alpine:3.9
 LABEL maintainer="mark.aaron.phelps@gmail.com"
 
-RUN apk add --no-cache postgresql-client \
+RUN apk add --no-cache \
+    ca-certificates \
     openssl \
-    ca-certificates
+    postgresql-client
 
 RUN mkdir -p /etc/flipt && \
     mkdir -p /var/opt/flipt
 
-COPY flipt /
+COPY --from=build /go/bin/flipt /
 COPY config /etc/flipt/config
 
 EXPOSE 8080
 EXPOSE 9000
 
-CMD ["./flipt"]
+CMD ["/flipt"]


### PR DESCRIPTION
To avoid depending on a local setup for the build and only using Docker as packaging, we can leverage multi-stage builds to guarantee build reproducibility while still keeping the final image clean and small.

It is possible to stop the build in a specific stage for development/debugging purposes with the `--target` flag, e.g. `docker build -t flipt --target build .`