### PR TITLE
Fix inconsistent segment matching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,16 +73,6 @@ dev: ## Build and run in development mode
 	@echo ">> building and running in development mode"
 	go run ./cmd/$(PROJECT)/. --config ./config/local.yml
 
-.PHONY: snapshot
-snapshot: ## Build a snapshot version
-	@echo ">> building a snapshot version"
-	@./script/build/snapshot
-
-.PHONY: release
-release: ## Build and publish a release
-	@echo ">> building and publishing a release"
-	@./script/build/release
-
 .PHONY: help
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/go.sum
+++ b/go.sum
@@ -309,4 +309,5 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
+honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc h1:/hemPrYIhOhy8zYrNj+069zDB68us2sMGsfkFJO0iZs=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/storage/db_test.go
+++ b/storage/db_test.go
@@ -77,10 +77,10 @@ func TestParse(t *testing.T) {
 var (
 	logger *logrus.Logger
 
-	flagStore    FlagStore
-	segmentStore SegmentStore
-	ruleStore    RuleStore
-	evaluator    Evaluator
+	flagStore    *FlagStorage
+	segmentStore *SegmentStorage
+	ruleStore    *RuleStorage
+	evaluator    *EvaluatorStorage
 )
 
 const defaultTestDBURL = "file:../flipt_test.db"
@@ -94,7 +94,11 @@ func TestMain(m *testing.M) {
 func run(m *testing.M) int {
 	logger = logrus.New()
 	logger.Level = logrus.DebugLevel
-	logger.Out = ioutil.Discard
+
+	debug := os.Getenv("DEBUG")
+	if debug == "" {
+		logger.Out = ioutil.Discard
+	}
 
 	dbURL := os.Getenv("DB_URL")
 	if dbURL == "" {

--- a/storage/evaluator_test.go
+++ b/storage/evaluator_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/gofrs/uuid"
 	flipt "github.com/markphelps/flipt/rpc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -448,6 +449,135 @@ func TestEvaluate_RolloutDistribution(t *testing.T) {
 			assert.Equal(t, matchesVariantKey, resp.Value)
 		})
 	}
+}
+
+func TestEvaluate_RolloutDistribution_WithMatchAll(t *testing.T) {
+	flag, err := flagStore.CreateFlag(context.TODO(), &flipt.CreateFlagRequest{
+		Key:         t.Name(),
+		Name:        t.Name(),
+		Description: "foo",
+		Enabled:     true,
+	})
+
+	require.NoError(t, err)
+
+	var variants []*flipt.Variant
+
+	for _, req := range []*flipt.CreateVariantRequest{
+		{
+			FlagKey: flag.Key,
+			Key:     fmt.Sprintf("released_%s", t.Name()),
+		},
+		{
+			FlagKey: flag.Key,
+			Key:     fmt.Sprintf("unreleased_%s", t.Name()),
+		},
+	} {
+		variant, err := flagStore.CreateVariant(context.TODO(), req)
+		require.NoError(t, err)
+		variants = append(variants, variant)
+	}
+
+	// subscriber segment
+	subscriberSegment, err := segmentStore.CreateSegment(context.TODO(), &flipt.CreateSegmentRequest{
+		Key:  fmt.Sprintf("subscriber_%s", t.Name()),
+		Name: fmt.Sprintf("subscriber %s", t.Name()),
+	})
+
+	require.NoError(t, err)
+
+	// subscriber segment constraint: premium_user (bool) == true
+	_, err = segmentStore.CreateConstraint(context.TODO(), &flipt.CreateConstraintRequest{
+		SegmentKey: subscriberSegment.Key,
+		Type:       flipt.ComparisonType_BOOLEAN_COMPARISON_TYPE,
+		Property:   "premium_user",
+		Operator:   opTrue,
+	})
+
+	require.NoError(t, err)
+
+	// subscriber segment rollout distribution of 50/50
+	rolloutRule, err := ruleStore.CreateRule(context.TODO(), &flipt.CreateRuleRequest{
+		FlagKey:    flag.Key,
+		SegmentKey: subscriberSegment.Key,
+	})
+
+	require.NoError(t, err)
+
+	for _, req := range []*flipt.CreateDistributionRequest{
+		{
+			FlagKey:   flag.Key,
+			RuleId:    rolloutRule.Id,
+			VariantId: variants[0].Id,
+			Rollout:   50,
+		},
+		{
+			FlagKey:   flag.Key,
+			RuleId:    rolloutRule.Id,
+			VariantId: variants[1].Id,
+			Rollout:   50,
+		},
+	} {
+		_, err := ruleStore.CreateDistribution(context.TODO(), req)
+		require.NoError(t, err)
+	}
+
+	// all users segment
+	allUsersSegment, err := segmentStore.CreateSegment(context.TODO(), &flipt.CreateSegmentRequest{
+		Key:  fmt.Sprintf("all_users_%s", t.Name()),
+		Name: fmt.Sprintf("all users %s", t.Name()),
+	})
+
+	require.NoError(t, err)
+
+	// all users segment return unreleased
+	allUsersRule, err := ruleStore.CreateRule(context.TODO(), &flipt.CreateRuleRequest{
+		FlagKey:    flag.Key,
+		SegmentKey: allUsersSegment.Key,
+	})
+
+	require.NoError(t, err)
+
+	_, err = ruleStore.CreateDistribution(context.TODO(), &flipt.CreateDistributionRequest{
+		FlagKey:   flag.Key,
+		RuleId:    allUsersRule.Id,
+		VariantId: variants[1].Id,
+		Rollout:   100,
+	})
+
+	require.NoError(t, err)
+
+	var (
+		uuid                   = uuid.Must(uuid.NewV4())
+		subscriberSegmentCount = 0
+		allUsersSegmentCount   = 0
+	)
+
+	for i := 0; i < 5; i++ {
+		resp, err := evaluator.Evaluate(context.TODO(), &flipt.EvaluationRequest{
+			FlagKey:  flag.Key,
+			EntityId: uuid.String(),
+			Context: map[string]string{
+				"premium_user": "true",
+			},
+		})
+
+		require.NoError(t, err)
+
+		assert.NotNil(t, resp)
+		assert.True(t, resp.Match)
+
+		if resp.SegmentKey == subscriberSegment.Key {
+			subscriberSegmentCount++
+		} else if resp.SegmentKey == allUsersSegment.Key {
+			allUsersSegmentCount++
+		} else {
+			require.FailNowf(t, "unknown segment key: %s", resp.SegmentKey)
+		}
+	}
+
+	assert.Equal(t, 5, subscriberSegmentCount)
+	assert.Equal(t, 0, allUsersSegmentCount)
 }
 
 func TestEvaluate_NoConstraints(t *testing.T) {


### PR DESCRIPTION
Fixes: #166 

Was [ranging over a map of rules](https://github.com/markphelps/flipt/pull/168/files#diff-2a28b7ff422916110e588eb24cbce69dL124) which is inconsistent per the [spec](https://golang.org/ref/spec#For_statements):

> The iteration order over maps is not specified and is not guaranteed to be the same from one iteration to the next. 