### PR TITLE
Add pagination for flags and segments in UI

### DIFF
--- a/config/local.yml
+++ b/config/local.yml
@@ -1,6 +1,25 @@
 log:
   level: DEBUG
 
+# ui:
+#   enabled: true
+
+# cors:
+#   enabled: false
+#   allowed_origins: "*"
+
+# cache:
+#   memory:
+#     enabled: false
+#     items: 500
+
+# server:
+#   protocol: http
+#   host: 0.0.0.0
+#   https_port: 443
+#   http_port: 8080
+#   grpc_port: 9000
+
 db:
   url: file:flipt.db
   migrations:

--- a/ui/src/components/Flags.vue
+++ b/ui/src/components/Flags.vue
@@ -4,7 +4,7 @@
       <div class="level">
         <div class="level-left">
           <div class="level-item">
-            <div v-if="flags.length > 5" class="field has-addons">
+            <div v-if="flags.length > 10" class="field has-addons">
               <p class="control">
                 <input
                   v-model="search"
@@ -25,7 +25,13 @@
           </div>
         </div>
       </div>
-      <b-table :data="filteredFlags">
+      <b-table
+        :data="filteredFlags"
+        :paginated="flags.length > 20"
+        per-page="20"
+        icon-pack="fas"
+        hoverable="true"
+      >
         <template slot-scope="props">
           <b-table-column field="enabled" label="Enabled">
             <span v-if="props.row.enabled" class="tag is-primary is-rounded"
@@ -43,7 +49,7 @@
               {{ props.row.name }}
             </RouterLink>
           </b-table-column>
-          <b-table-column field="hasVariants" label="Variants" sortable>
+          <b-table-column field="hasVariants" label="Variants">
             {{ props.row.variants ? "yes" : "no" }}
           </b-table-column>
           <b-table-column field="description" label="Description">

--- a/ui/src/components/Flags/Rule.vue
+++ b/ui/src/components/Flags/Rule.vue
@@ -11,7 +11,15 @@
           </div>
           <div class="field-body">
             <div class="field">
-              <span class="tag is-medium"> {{ segmentName }} </span>
+              <b-tooltip :label="segmentName" type="is-dark">
+                <span class="tag is-medium">
+                  <RouterLink
+                    :to="{ name: 'segment', params: { key: segmentKey } }"
+                  >
+                    {{ segmentKey }}
+                  </RouterLink>
+                </span>
+              </b-tooltip>
             </div>
           </div>
         </div>
@@ -81,6 +89,7 @@
 export default {
   props: {
     id: String,
+    segmentKey: String,
     segmentName: String,
     index: Number,
     distributions: Array

--- a/ui/src/components/Flags/Rule.vue
+++ b/ui/src/components/Flags/Rule.vue
@@ -11,12 +11,12 @@
           </div>
           <div class="field-body">
             <div class="field">
-              <b-tooltip :label="segmentName" type="is-dark">
+              <b-tooltip :label="segmentKey" type="is-dark">
                 <span class="tag is-medium">
                   <RouterLink
                     :to="{ name: 'segment', params: { key: segmentKey } }"
                   >
-                    {{ segmentKey }}
+                    {{ segmentName }}
                   </RouterLink>
                 </span>
               </b-tooltip>

--- a/ui/src/components/Segments.vue
+++ b/ui/src/components/Segments.vue
@@ -4,7 +4,7 @@
       <div class="level">
         <div class="level-left">
           <div class="level-item">
-            <div v-if="segments.length > 5" class="field has-addons">
+            <div v-if="segments.length > 10" class="field has-addons">
               <p class="control">
                 <input
                   v-model="search"
@@ -25,7 +25,13 @@
           </div>
         </div>
       </div>
-      <b-table :data="filteredSegments">
+      <b-table
+        :data="filteredSegments"
+        :paginated="segments.length > 20"
+        per-page="20"
+        icon-pack="fas"
+        hoverable="true"
+      >
         <template slot-scope="props">
           <b-table-column field="key" label="Key" sortable>
             <RouterLink


### PR DESCRIPTION
Fixes: #190 

* Add pagination for flags and segments in UI
* Show segment key and link to segment in targeting

## Pagination (over 20 items)

<img width="1214" alt="Screen Shot 2019-11-29 at 10 47 00 AM" src="https://user-images.githubusercontent.com/209477/69879793-63fada00-1296-11ea-96a5-03955bc96c76.png">

## 