### PR TITLE
fix 0% distribution issues

### DIFF
--- a/server/evaluator.go
+++ b/server/evaluator.go
@@ -168,16 +168,16 @@ func (s *Server) evaluate(ctx context.Context, r *flipt.EvaluationRequest) (*fli
 			buckets            []int
 		)
 
-		for i, d := range distributions {
+		for _, d := range distributions {
 			// don't include 0% rollouts
 			if d.Rollout > 0 {
 				validDistributions = append(validDistributions, d)
 
-				if i == 0 {
+				if buckets == nil {
 					bucket := int(d.Rollout * percentMultiplier)
 					buckets = append(buckets, bucket)
 				} else {
-					bucket := buckets[i-1] + int(d.Rollout*percentMultiplier)
+					bucket := buckets[len(buckets)-1] + int(d.Rollout*percentMultiplier)
 					buckets = append(buckets, bucket)
 				}
 			}


### PR DESCRIPTION
The current implementation skips over distributions that have a 0% rollout and build a buckets array.
The buckets array is accessed by index, but since we skip all 0% distributions, the index of the loop can get out of sync with the last index of the buckets array, creating index out of range errors.

This adds 2 tests specific for the issue and fixes them.

Let me know if this needs updating / re-working.