### PR TITLE
Fix grpc insecure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2.5.2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.33
+          version: v1.40
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ run:
   #   	vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
   skip-dirs:
     - "bin"
+    - "_tools"
     - "dist"
     - "docs"
     - "rpc"
@@ -32,14 +33,11 @@ linters:
     - errcheck
     - goconst
     - gocritic
-    #- godox
     - goimports
-    - golint
     - gosec
     - gosimple
     - govet
     - ineffassign
-    - interfacer
     - megacheck
     - misspell
     - staticcheck

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ fmt: ## Run gofmt and goimports on all go files
 .PHONY: lint
 lint: ## Run all the linters
 	@echo ">> running golangci-lint"
-	golangci-lint run
+	golangci-lint run 2>&1
 
 .PHONY: clean
 clean: ## Cleanup generated files

--- a/cmd/flipt/main.go
+++ b/cmd/flipt/main.go
@@ -42,6 +42,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/reflection"
 
 	_ "github.com/golang-migrate/migrate/source/file"
@@ -374,7 +375,7 @@ func run(_ []string) error {
 			opts = append(opts, grpc.WithTransportCredentials(creds))
 			httpPort = cfg.Server.HTTPSPort
 		case config.HTTP:
-			opts = append(opts, grpc.WithInsecure())
+			opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 			httpPort = cfg.Server.HTTPPort
 		}
 

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-go get github.com/grpc-ecosystem/grpc-gateway/v2@v2.7.0
-
 TOOLS=$(pwd)/_tools
 export GOBIN=$TOOLS/bin
 

--- a/server/server.go
+++ b/server/server.go
@@ -56,7 +56,7 @@ func (s *Server) ValidationUnaryInterceptor(ctx context.Context, req interface{}
 func (s *Server) ErrorUnaryInterceptor(ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
 	resp, err = handler(ctx, req)
 	if err == nil {
-		return
+		return resp, nil
 	}
 
 	errorsTotal.Inc()

--- a/storage/db/common/rule.go
+++ b/storage/db/common/rule.go
@@ -169,6 +169,7 @@ func (s *Store) DeleteRule(ctx context.Context, r *flipt.DeleteRuleRequest) erro
 	}
 
 	// delete rule
+	//nolint
 	_, err = s.builder.Delete("rules").
 		RunWith(tx).
 		Where(sq.And{sq.Eq{"id": r.Id}, sq.Eq{"flag_key": r.FlagKey}}).


### PR DESCRIPTION
* Uses `grpc.WithTransportCredentials(insecure.NewCredentials())`
* Upgrade linter version
* Fix linter errors