### PR TITLE
Add ability to quickly duplicate constraints/variants

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -69,7 +69,7 @@ tasks:
       - buf generate
 
   clean:
-    desc: Rm built assets
+    desc: Remove built assets
     cmds:
       - go clean -i {{.SOURCE_FILES}}
       - rm -rf dist/*
@@ -84,7 +84,7 @@ tasks:
       COVERAGE_FILE: coverage.txt
 
   dev:
-    desc: Start the server and ui in development modes
+    desc: Start the server and UI in development modes
     cmds:
       - modd
     preconditions:
@@ -97,13 +97,13 @@ tasks:
       - goimports -w .
 
   lint:
-    desc: Run linters
+    desc: Run the linters
     cmds:
       - golangci-lint run 2>&1
       - buf lint
 
   test:
-    desc: Run all tests
+    desc: Run all the tests
     cmds:
       - go test {{.TEST_OPTS}} -covermode=atomic -count=1 -coverprofile={{.COVERAGE_FILE}} {{.SOURCE_FILES}} -run={{.TEST_PATTERN}} -timeout=30s {{.TEST_FLAGS}}
     vars:

--- a/modd.conf
+++ b/modd.conf
@@ -1,5 +1,5 @@
-**/*.go !**/*_test.go {
-    daemon +sigterm: go run ./cmd/flipt/. --config ./config/local.yml --force-migrate
+{
+    daemon: go run ./cmd/flipt/. --config ./config/local.yml --force-migrate
 }
 {
     indir: ./ui

--- a/ui/src/components/Flags/Flag.vue
+++ b/ui/src/components/Flags/Flag.vue
@@ -107,20 +107,30 @@
           >
             {{ props.row.attachment | limit }}
           </b-table-column>
-          <b-table-column v-slot="props" field="" label="" width="110" centered>
+          <b-table-column v-slot="props" field="" label="" width="160" centered>
             <a
               class="button is-white"
               @click.prevent="editVariant(props.index)"
             >
               <span class="icon is-small">
-                <i class="fas fa-pencil-alt" />
+                <i class="fas fa-pencil-alt" title="Edit" />
+              </span>
+            </a>
+            <a
+              class="button is-white"
+              @click.prevent="duplicateVariant(props.index)"
+            >
+              <span class="icon is-small">
+                <i class="fas fa-clone" title="Duplicate" />
               </span>
             </a>
             <a
               class="button is-white"
               @click.prevent="deleteVariant(props.index)"
             >
-              <span class="icon is-small"> <i class="fas fa-times" /> </span>
+              <span class="icon is-small">
+                <i class="fas fa-times" title="Delete" />
+              </span>
             </a>
           </b-table-column>
         </b-table>
@@ -461,6 +471,10 @@ export default {
     editVariant(index) {
       this.dialogEditVariantVisible = true;
       this.selectedVariant = cloneDeep(this.flag.variants[index]);
+    },
+    duplicateVariant(index) {
+      this.dialogAddVariantVisible = true;
+      this.newVariant = cloneDeep(this.flag.variants[index]);
     },
     cancelEditVariant() {
       this.dialogEditVariantVisible = false;

--- a/ui/src/components/Flags/Flag.vue
+++ b/ui/src/components/Flags/Flag.vue
@@ -121,7 +121,7 @@
               @click.prevent="duplicateVariant(props.index)"
             >
               <span class="icon is-small">
-                <i class="fas fa-clone" title="Duplicate" />
+                <i class="far fa-clone" title="Duplicate" />
               </span>
             </a>
             <a

--- a/ui/src/components/Segments/Segment.vue
+++ b/ui/src/components/Segments/Segment.vue
@@ -114,20 +114,30 @@
           <b-table-column v-slot="props" field="value" label="Value">
             {{ props.row.value }}
           </b-table-column>
-          <b-table-column v-slot="props" field="" label="" width="110" centered>
+          <b-table-column v-slot="props" field="" label="" width="160" centered>
             <a
               class="button is-white"
               @click.prevent="editConstraint(props.index)"
             >
               <span class="icon is-small">
-                <i class="fas fa-pencil-alt" />
+                <i class="fas fa-pencil-alt" title="Edit" />
+              </span>
+            </a>
+            <a
+              class="button is-white"
+              @click.prevent="duplicateConstraint(props.index)"
+            >
+              <span class="icon is-small">
+                <i class="fas fa-clone" title="Duplicate" />
               </span>
             </a>
             <a
               class="button is-white"
               @click.prevent="deleteConstraint(props.index)"
             >
-              <span class="icon is-small"> <i class="fas fa-times" /> </span>
+              <span class="icon is-small">
+                <i class="fas fa-times" title="Delete" />
+              </span>
             </a>
           </b-table-column>
         </b-table>
@@ -611,6 +621,10 @@ export default {
     editConstraint(index) {
       this.dialogEditConstraintVisible = true;
       this.selectedConstraint = cloneDeep(this.segment.constraints[index]);
+    },
+    duplicateConstraint(index) {
+      this.dialogAddConstraintVisible = true;
+      this.newConstraint = cloneDeep(this.segment.constraints[index]);
     },
     cancelEditConstraint() {
       this.dialogEditConstraintVisible = false;

--- a/ui/src/components/Segments/Segment.vue
+++ b/ui/src/components/Segments/Segment.vue
@@ -128,7 +128,7 @@
               @click.prevent="duplicateConstraint(props.index)"
             >
               <span class="icon is-small">
-                <i class="fas fa-clone" title="Duplicate" />
+                <i class="far fa-clone" title="Duplicate" />
               </span>
             </a>
             <a


### PR DESCRIPTION
![Screen Shot 2022-03-17 at 9 27 58 PM](https://user-images.githubusercontent.com/209477/158920049-e44878ae-f194-4638-bf87-344d1f05a2b1.png)

While working on setting up a simliar example as described in #732 in order to start working on a solution, I realized that it was very tedious to create constraints (and variants) that were based on existing ones with only minor differences.

Example:

```
Constraint 1: { property: 'environment', operator: 'eq', value: 'development' }

Constraint 2: { property: 'environment', operator: 'eq', value: 'staging' }
```

In this example the constraints only differ by the 'value', but in order to create these contraints in the UI I had to start from scratch each time.

This PR adds
1.  'duplicate' functionality in the UI for constraints and variants
2. labels for the icons in the constraints/variants tables
3. Minor description changes in the Taskfile.

## Demo

![constraint-dupe](https://user-images.githubusercontent.com/209477/158919122-d8f7fe13-a5dc-4759-add9-b85500b9a673.gif)
