### PR TITLE
Upgrade go-chi/chi to commit that handles Vary header properly

### DIFF
--- a/cmd/flipt/main.go
+++ b/cmd/flipt/main.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/fatih/color"
-	"github.com/go-chi/chi"
-	"github.com/go-chi/chi/middleware"
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/cors"
 	"github.com/google/go-github/v32/github"
 	"github.com/markphelps/flipt/config"

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/fatih/color v1.13.0
-	github.com/go-chi/chi v4.1.2+incompatible
+	github.com/go-chi/chi/v5 v5.0.8-0.20220103191336-b750c805b4ee // indirect
 	github.com/go-chi/cors v1.2.0
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/gofrs/uuid v4.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,8 @@ github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYF
 github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/go-chi/chi v4.1.2+incompatible h1:fGFk2Gmi/YKXk0OmGfBh0WgmN3XB8lVnEyNz34tQRec=
-github.com/go-chi/chi v4.1.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
+github.com/go-chi/chi/v5 v5.0.8-0.20220103191336-b750c805b4ee h1:TCfv9Po2jPE4mN7sjzztbsc40otGpWXx7u4SVN05qeo=
+github.com/go-chi/chi/v5 v5.0.8-0.20220103191336-b750c805b4ee/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-chi/cors v1.2.0 h1:tV1g1XENQ8ku4Bq3K9ub2AtgG+p16SmzeMSGTwrOKdE=
 github.com/go-chi/cors v1.2.0/go.mod h1:sSbTewc+6wYHBBCW7ytsFSn836hqM7JxpglAy2Vzc58=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=


### PR DESCRIPTION
Fixes https://github.com/markphelps/flipt/issues/802

For CORS, the server needs to include `Origin` in the `Vary` response (if `Access-Control-Allow-Origin` is not set to `*`)
https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#access-control-allow-origin

Flipt is using go-chi/cors to handle CORS which does include that header
https://github.com/go-chi/cors/blob/9b0b248d5e6ba10c954f076a98c5f7760f243882/cors.go#L242-L247

However, if the request includes `Accept-Encoding`, this triggers this line
https://github.com/go-chi/chi/blob/86f9a6e7ce9bf453eaa339b51f88f586edbccbc1/middleware/compress.go#L321
which overrides any previously set Vary headers

N.B. `Accept-Encoding` is a forbidden header https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name
meaning it can only be set by the user agent and cannot be modified in JS as a workaround

This bug was fixed in https://github.com/go-chi/chi/pull/640, so this
commit updates go-chi/chi to that commit hash with
`go get github.com/go-chi/chi/v5@b750c805b4ee0952b`