### PR TITLE
Ignore major dependabot upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
     assignees:
       - markphelps
     ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
       - dependency-name: github.com/golangci/golangci-lint
         versions:
           - "> 1.26.0"
@@ -24,6 +27,9 @@ updates:
     assignees:
       - markphelps
     ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
       - dependency-name: github.com/golangci/golangci-lint
         versions:
           - "> 1.26.0"
@@ -37,6 +43,10 @@ updates:
       - markphelps
     assignees:
       - markphelps
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
 
   - package-ecosystem: "github-actions"
     # Workflow files stored in the


### PR DESCRIPTION
Ignore PRs from dependabot for major version updates as these are risky and should be done manually

See: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore